### PR TITLE
Added plain uint64_t decoder, for comparison.

### DIFF
--- a/u64.cpp
+++ b/u64.cpp
@@ -1,0 +1,40 @@
+// Copyright 2016 Jakob Stoklund Olesen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This implements the u64 codec: just pass-thru uint64_t for comparison.
+
+#include "compiler.h"
+#include "varint.h"
+
+using namespace std;
+
+vector<uint8_t> u64_encode(const vector<uint64_t> &in) {
+  vector<uint8_t> out;
+  for (auto x : in) {
+    out.insert(out.end(), reinterpret_cast<uint8_t *>(&x), reinterpret_cast<uint8_t *>(&x) + sizeof(uint64_t));
+  }
+  return out;
+}
+
+void u64_decode(const uint8_t *in, uint64_t *out, size_t count) {
+  while (count-- > 0) {
+    std::memcpy(out, in, sizeof(uint64_t));
+    out++;
+    in += sizeof(uint64_t);
+  }
+}
+
+const codec_descriptor u64_codec = {
+    .name = "U64", .encoder = u64_encode, .decoder = u64_decode,
+};

--- a/varint.cpp
+++ b/varint.cpp
@@ -128,8 +128,10 @@ int main(int argc, const char *argv[]) {
   double prefix = do_codec(prefix_codec, numbers);
   double sqlite = do_codec(lesqlite_codec, numbers);
   double sqlite2 = do_codec(lesqlite2_codec, numbers);
+  double u64 = do_codec(u64_codec, numbers);
 
   printf("T(LEB128) / T(PrefixVarint) = %.3f.\n", leb128 / prefix);
   printf("T(LEB128) / T(leSQLite) = %.3f.\n", leb128 / sqlite);
   printf("T(LEB128) / T(leSQLite2) = %.3f.\n", leb128 / sqlite2);
+  printf("T(LEB128) / T(U64) = %.3f.\n", leb128 / u64);
 }

--- a/varint.h
+++ b/varint.h
@@ -28,3 +28,4 @@ extern const codec_descriptor leb128_codec;
 extern const codec_descriptor prefix_codec;
 extern const codec_descriptor lesqlite_codec;
 extern const codec_descriptor lesqlite2_codec;
+extern const codec_descriptor u64_codec;


### PR DESCRIPTION
This is useful when deciding on wether to use a variable encoding
at all. Speed depends on many factors, but can easily be close to 10x.